### PR TITLE
change to use .clang-tidy config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
         args: [--markdown-linebreak-ext=md]
 
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.3.0
     hooks:
       - id: black
 

--- a/codechecker-config.json
+++ b/codechecker-config.json
@@ -1,9 +1,10 @@
 {
-  "analyzer": [
+  "analyze": [
     "--jobs=2",
     "--analyzers=clang-tidy",
     "--timeout=300",
     "--clean",
-    "--disable=bugprone-infinite-loop"
+    "--analyzer-config",
+    "clang-tidy:take-config-from-directory=true"
   ]
 }


### PR DESCRIPTION
Currently, ros-metrics-reporter uses [codechecker-config.json](https://github.com/tier4/ros-metrics-reporter/blob/main/codechecker-config.json) to pass configurations to clang-tidy.
To improve maintainability, clang-tidy settings are changed so that they can be described in `.clang-tidy` files.

Reference: https://github.com/Ericsson/codechecker/blob/master/docs/analyzer/checker_and_analyzer_configuration.md#using-clang-tidy-configuration-files

Signed-off-by: Keisuke Shima <19993104+KeisukeShima@users.noreply.github.com>